### PR TITLE
Prevent user from displaying a graph before attributes are loaded

### DIFF
--- a/frontend/src/components/menu/FilterSection.tsx
+++ b/frontend/src/components/menu/FilterSection.tsx
@@ -6,6 +6,7 @@ import "./FilterSection.css";
 type FiltersSectionProps = {
   attributes: Array<Attribute>;
   filters: Filters;
+  disabled: boolean;
   onChange: (f: Filters) => void;
 };
 
@@ -81,7 +82,11 @@ export default class FiltersSection extends Component<FiltersSectionProps, {}> {
     return (
       <div className="Section">
         <div className="Title">
-          <button className="Add-button" onClick={this.add}>
+          <button
+            className="Add-button"
+            onClick={this.add}
+            disabled={this.props.disabled}
+          >
             Add
           </button>
           Filter

--- a/frontend/src/components/menu/Menu.css
+++ b/frontend/src/components/menu/Menu.css
@@ -38,6 +38,8 @@
   border: 0;
   color: var(--color2);
   background: white;
+  border-radius: 3px;
+  border: 1px solid var(--color1);
 }
 
 .Menu select {
@@ -64,9 +66,11 @@
   border: 1px solid var(--color1);
 }
 
-.Menu button {
-  border-radius: 3px;
-  border: 1px solid var(--color1);
+.Menu button:disabled,
+.Menu select:disabled,
+.Menu input:disabled[type="text"],
+.Menu input:disabled[type="number"] {
+  background-color: #ddd;
 }
 
 .Menu .Filter-control {

--- a/frontend/src/components/menu/Menu.tsx
+++ b/frontend/src/components/menu/Menu.tsx
@@ -82,7 +82,7 @@ export default class Menu extends Component<MenuProps, MenuState> {
 
   go() {
     let params = this.state.graphParams;
-    if (params.volume === 0) {
+    if (params.volume === 0 && this.props.attributes.length > 0) {
       params.volume = this.props.attributes.filter(
         e => e.type === "edge"
       )[0].id;
@@ -92,6 +92,8 @@ export default class Menu extends Component<MenuProps, MenuState> {
   }
 
   render() {
+    const disabled = !this.props.attributes.length;
+
     var multiDim = (
       <>
         <ul id="dimensions-src">
@@ -161,6 +163,7 @@ export default class Menu extends Component<MenuProps, MenuState> {
           <div className="Title">Graph type</div>
           <select
             id="graph-type"
+            disabled={disabled}
             value={this.state.graphType}
             onChange={e => this.setState({ graphType: e.target.value })}
           >
@@ -173,6 +176,7 @@ export default class Menu extends Component<MenuProps, MenuState> {
           <div className="Title">Volume</div>
           <select
             id="volume"
+            disabled={disabled}
             onChange={this.onVolumeChanged}
             value={this.state.graphParams.volume}
           >
@@ -195,6 +199,7 @@ export default class Menu extends Component<MenuProps, MenuState> {
         <FiltersSection
           attributes={this.props.attributes}
           filters={this.state.graphParams.filters}
+          disabled={disabled}
           onChange={this.onFiltersChanged}
         />
 
@@ -202,13 +207,14 @@ export default class Menu extends Component<MenuProps, MenuState> {
           <div className="Title">Max values</div>
           <input
             type="number"
+            disabled={disabled}
             value={this.state.graphParams.maxValues}
             onChange={this.onMaxValuesChanged}
           />
         </div>
 
         <div className="Section">
-          <button className="Go" onClick={this.go}>
+          <button className="Go" onClick={this.go} disabled={disabled}>
             Go
           </button>
         </div>


### PR DESCRIPTION
Fixes: https://github.com/criteo/skydive-visualizer/issues/1